### PR TITLE
Improve validation in the grant types to catch empty inputs

### DIFF
--- a/src/League/OAuth2/Server/Grant/AuthCode.php
+++ b/src/League/OAuth2/Server/Grant/AuthCode.php
@@ -77,15 +77,15 @@ class AuthCode implements GrantTypeInterface
         // Auth params
         $authParams = $this->authServer->getParam(array('client_id', 'redirect_uri', 'response_type', 'scope', 'state'), 'get', $inputParams);
 
-        if (is_null($authParams['client_id'])) {
+        if (empty($authParams['client_id'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_id'), 0);
         }
 
-        if (is_null($authParams['redirect_uri'])) {
+        if (empty($authParams['redirect_uri'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'redirect_uri'), 0);
         }
 
-        if ($this->authServer->stateParamRequired() === true && is_null($authParams['state'])) {
+        if ($this->authServer->stateParamRequired() === true && empty($authParams['state'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'state'), 0);
         }
 
@@ -98,7 +98,7 @@ class AuthCode implements GrantTypeInterface
 
         $authParams['client_details'] = $clientDetails;
 
-        if (is_null($authParams['response_type'])) {
+        if (empty($authParams['response_type'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'response_type'), 0);
         }
 
@@ -185,15 +185,15 @@ class AuthCode implements GrantTypeInterface
         // Get the required params
         $authParams = $this->authServer->getParam(array('client_id', 'client_secret', 'redirect_uri', 'code'), 'post', $inputParams);
 
-        if (is_null($authParams['client_id'])) {
+        if (empty($authParams['client_id'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_id'), 0);
         }
 
-        if (is_null($authParams['client_secret'])) {
+        if (empty($authParams['client_secret'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_secret'), 0);
         }
 
-        if (is_null($authParams['redirect_uri'])) {
+        if (empty($authParams['redirect_uri'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'redirect_uri'), 0);
         }
 
@@ -207,7 +207,7 @@ class AuthCode implements GrantTypeInterface
         $authParams['client_details'] = $clientDetails;
 
         // Validate the authorization code
-        if (is_null($authParams['code'])) {
+        if (empty($authParams['code'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'code'), 0);
         }
 

--- a/src/League/OAuth2/Server/Grant/ClientCredentials.php
+++ b/src/League/OAuth2/Server/Grant/ClientCredentials.php
@@ -88,11 +88,11 @@ class ClientCredentials implements GrantTypeInterface
          // Get the required params
         $authParams = $this->authServer->getParam(array('client_id', 'client_secret'), 'post', $inputParams);
 
-        if (is_null($authParams['client_id'])) {
+        if (empty($authParams['client_id'])) {
             throw new Exception\ClientException(sprintf(Authorization::getExceptionMessage('invalid_request'), 'client_id'), 0);
         }
 
-        if (is_null($authParams['client_secret'])) {
+        if (empty($authParams['client_secret'])) {
             throw new Exception\ClientException(sprintf(Authorization::getExceptionMessage('invalid_request'), 'client_secret'), 0);
         }
 

--- a/src/League/OAuth2/Server/Grant/Password.php
+++ b/src/League/OAuth2/Server/Grant/Password.php
@@ -89,11 +89,11 @@ class Password implements GrantTypeInterface
         // Get the required params
         $authParams = $this->authServer->getParam(array('client_id', 'client_secret', 'username', 'password'), 'post', $inputParams);
 
-        if (is_null($authParams['client_id'])) {
+        if (empty($authParams['client_id'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_id'), 0);
         }
 
-        if (is_null($authParams['client_secret'])) {
+        if (empty($authParams['client_secret'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_secret'), 0);
         }
 
@@ -106,11 +106,11 @@ class Password implements GrantTypeInterface
 
         $authParams['client_details'] = $clientDetails;
 
-        if (is_null($authParams['username'])) {
+        if (empty($authParams['username'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'username'), 0);
         }
 
-        if (is_null($authParams['password'])) {
+        if (empty($authParams['password'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'password'), 0);
         }
 

--- a/src/League/OAuth2/Server/Grant/RefreshToken.php
+++ b/src/League/OAuth2/Server/Grant/RefreshToken.php
@@ -102,11 +102,11 @@ class RefreshToken implements GrantTypeInterface
         // Get the required params
         $authParams = $this->authServer->getParam(array('client_id', 'client_secret', 'refresh_token', 'scope'), 'post', $inputParams);
 
-        if (is_null($authParams['client_id'])) {
+        if (empty($authParams['client_id'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_id'), 0);
         }
 
-        if (is_null($authParams['client_secret'])) {
+        if (empty($authParams['client_secret'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'client_secret'), 0);
         }
 
@@ -119,7 +119,7 @@ class RefreshToken implements GrantTypeInterface
 
         $authParams['client_details'] = $clientDetails;
 
-        if (is_null($authParams['refresh_token'])) {
+        if (empty($authParams['refresh_token'])) {
             throw new Exception\ClientException(sprintf($this->authServer->getExceptionMessage('invalid_request'), 'refresh_token'), 0);
         }
 

--- a/tests/authorization/AuthCodeGrantTest.php
+++ b/tests/authorization/AuthCodeGrantTest.php
@@ -66,6 +66,20 @@ class Auth_Code_Grant_Test extends PHPUnit_Framework_TestCase
      * @expectedException        League\OAuth2\Server\Exception\ClientException
      * @expectedExceptionCode    0
      */
+    public function test_checkAuthoriseParams_emptyClientId()
+    {
+        $a = $this->returnDefault();
+        $g = new League\OAuth2\Server\Grant\AuthCode();
+        $a->addGrantType($g);
+        $g->checkAuthoriseParams(array(
+            'client_id' =>  ''
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
     public function test_checkAuthoriseParams_noRedirectUri()
     {
         $a = $this->returnDefault();
@@ -73,6 +87,21 @@ class Auth_Code_Grant_Test extends PHPUnit_Framework_TestCase
         $a->addGrantType($g);
         $g->checkAuthoriseParams(array(
             'client_id' =>  1234
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_checkAuthoriseParams_emptyRedirectUri()
+    {
+        $a = $this->returnDefault();
+        $g = new League\OAuth2\Server\Grant\AuthCode();
+        $a->addGrantType($g);
+        $g->checkAuthoriseParams(array(
+            'client_id' =>  1234,
+            'redirect_uri'  =>  ''
         ));
     }
 
@@ -129,6 +158,29 @@ class Auth_Code_Grant_Test extends PHPUnit_Framework_TestCase
         $g->checkAuthoriseParams(array(
             'client_id' =>  1234,
             'redirect_uri'  =>  'http://foo/redirect'
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_checkAuthoriseParams_emptyResponseType()
+    {
+        $this->client->shouldReceive('getClient')->andReturn(array(
+            'client_id' =>  1234,
+            'client_secret' =>  5678,
+            'redirect_uri'  =>  'http://foo/redirect',
+            'name'  =>  'Example Client'
+        ));
+
+        $a = $this->returnDefault();
+        $g = new League\OAuth2\Server\Grant\AuthCode();
+        $a->addGrantType($g);
+        $g->checkAuthoriseParams(array(
+            'client_id' =>  1234,
+            'redirect_uri'  =>  'http://foo/redirect',
+            'response_type' =>  ''
         ));
     }
 

--- a/tests/authorization/ClientCredentialsGrantTest.php
+++ b/tests/authorization/ClientCredentialsGrantTest.php
@@ -41,7 +41,25 @@ class Client_Credentials_Grant_Test extends PHPUnit_Framework_TestCase
      * @expectedException        League\OAuth2\Server\Exception\ClientException
      * @expectedExceptionCode    0
      */
-    public function test_issueAccessToken_clientCredentialsGrant_missingClientPassword()
+    public function test_issueAccessToken_clientCredentialsGrant_emptyClientId()
+    {
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\ClientCredentials());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'client_credentials',
+            'client_id' =>  ''
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_issueAccessToken_clientCredentialsGrant_missingClientSecret()
     {
         $a = $this->returnDefault();
         $a->addGrantType(new League\OAuth2\Server\Grant\ClientCredentials());
@@ -52,6 +70,25 @@ class Client_Credentials_Grant_Test extends PHPUnit_Framework_TestCase
         $a->issueAccessToken(array(
             'grant_type'    =>  'client_credentials',
             'client_id' =>  1234
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_issueAccessToken_clientCredentialsGrant_emptyClientSecret()
+    {
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\ClientCredentials());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'client_credentials',
+            'client_id' =>  1234,
+            'client_secret' =>  ''
         ));
     }
 

--- a/tests/authorization/PasswordGrantTest.php
+++ b/tests/authorization/PasswordGrantTest.php
@@ -41,7 +41,25 @@ class Password_Grant_Test extends PHPUnit_Framework_TestCase
      * @expectedException        League\OAuth2\Server\Exception\ClientException
      * @expectedExceptionCode    0
      */
-    public function test_issueAccessToken_passwordGrant_missingClientPassword()
+    public function test_issueAccessToken_passwordGrant_emptyClientId()
+    {
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\Password());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'password',
+            'client_id' =>  ''
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_issueAccessToken_passwordGrant_missingClientSecret()
     {
         $a = $this->returnDefault();
         $a->addGrantType(new League\OAuth2\Server\Grant\Password());
@@ -52,6 +70,25 @@ class Password_Grant_Test extends PHPUnit_Framework_TestCase
         $a->issueAccessToken(array(
             'grant_type'    =>  'password',
             'client_id' =>  1234
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_issueAccessToken_passwordGrant_emptyClientSecret()
+    {
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\Password());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'password',
+            'client_id' =>  1234,
+            'client_secret' =>  ''
         ));
     }
 

--- a/tests/authorization/RefreshTokenTest.php
+++ b/tests/authorization/RefreshTokenTest.php
@@ -91,6 +91,24 @@ class Refresh_Token_test extends PHPUnit_Framework_TestCase
      * @expectedException        League\OAuth2\Server\Exception\ClientException
      * @expectedExceptionCode    0
      */
+    public function test_issueAccessToken_refreshTokenGrant_emptyClientId()
+    {
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\RefreshToken());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'refresh_token',
+            'client_id' =>  ''
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
     public function test_issueAccessToken_refreshTokenGrant_missingClientSecret()
     {
         $a = $this->returnDefault();
@@ -102,6 +120,25 @@ class Refresh_Token_test extends PHPUnit_Framework_TestCase
         $a->issueAccessToken(array(
             'grant_type'    =>  'refresh_token',
             'client_id' =>  1234
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_issueAccessToken_refreshTokenGrant_emptyClientSecret()
+    {
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\RefreshToken());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'refresh_token',
+            'client_id' =>  1234,
+            'client_secret' =>  ''
         ));
     }
 
@@ -144,6 +181,28 @@ class Refresh_Token_test extends PHPUnit_Framework_TestCase
             'grant_type'    =>  'refresh_token',
             'client_id' =>  1234,
             'client_secret' =>  5678
+        ));
+    }
+
+    /**
+     * @expectedException        League\OAuth2\Server\Exception\ClientException
+     * @expectedExceptionCode    0
+     */
+    public function test_issueAccessToken_refreshTokenGrant_emptyRefreshToken()
+    {
+        $this->client->shouldReceive('getClient')->andReturn(array());
+
+        $a = $this->returnDefault();
+        $a->addGrantType(new League\OAuth2\Server\Grant\RefreshToken());
+
+        $request = new League\OAuth2\Server\Util\Request(array(), $_POST);
+        $a->setRequest($request);
+
+        $a->issueAccessToken(array(
+            'grant_type'    =>  'refresh_token',
+            'client_id' =>  1234,
+            'client_secret' =>  5678,
+            'refresh_token' =>  ''
         ));
     }
 


### PR DESCRIPTION
Improve the validation for all the grant types to prevent the use of empty inputs. 